### PR TITLE
Build rocr version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     tzdata \
     curl \
     xz-utils \
-    libpci3
+    libpci3 \
+    initramfs-tools
 
 FROM base AS amdgpu-legacy-base
 ARG AMD_SITE_URL="https://drivers.amd.com/drivers/linux/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ America/Caracas
 
 LABEL Name=amdgpu-legacy
-LABEL Version=0.1
+LABEL Version=0.2
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -20,5 +20,5 @@ ARG AMDGPU_VERSION="amdgpu-pro-20.45-1188099-ubuntu-20.04"
 
 RUN curl --referer ${AMD_SITE_URL} -O ${AMD_SITE_URL}${AMDGPU_VERSION}.tar.xz \
     && tar -Jxvf ${AMDGPU_VERSION}.tar.xz \
-    && ${AMDGPU_VERSION}/amdgpu-install -y --opencl=legacy --headless --no-dkms --no-32 \
+    && ${AMDGPU_VERSION}/amdgpu-install -y --opencl=rocr --headless --no-dkms --no-32 \
     && rm -rf amdgpu-pro-* /var/opt/amdgpu-pro-local /var/lib/apt/lists/*


### PR DESCRIPTION
We need to change the --opencl flag to rocr to build the version to support recent hardware.